### PR TITLE
Add support for module.exports / webpack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default function ({ Plugin, types: t }) {
+export default function ({ types: t }) {
   function buildDisplayName(filename) {
     return filename
       .replace(/^.*!([^!]+)$/, "$1") // Remove webpack stuff
@@ -46,7 +46,7 @@ export default function ({ Plugin, types: t }) {
     return true;
   }
 
-  return new Plugin("react-auto-display-name", {
+  return {
     metadata: {
       group: "builtin-pre"
     },
@@ -85,5 +85,5 @@ export default function ({ Plugin, types: t }) {
         }
       }
     }
-  });
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 export default function ({ Plugin, types: t }) {
   function buildDisplayName(filename) {
     return filename
+      .replace(/^.*!([^!]+)$/, "$1") // Remove webpack stuff
       .replace(/(.*)components/, '')
       .replace(/^\//, '')
-      .replace('.js', '')
+      .replace(/\.[a-z]+$/, '') // Remove extension
       .replace(/\/index$/, '')
       .replace(/\//g, '.');
   }
@@ -57,8 +58,8 @@ export default function ({ Plugin, types: t }) {
         }
       },
 
-      "AssignmentExpression|Property|VariableDeclarator"(node) {
-        var left, right;
+      "AssignmentExpression|Property|VariableDeclarator"(node, parent, scope, file) {
+        var left, right, filename;
 
         if (t.isAssignmentExpression(node)) {
           left = node.left;
@@ -72,11 +73,15 @@ export default function ({ Plugin, types: t }) {
         }
 
         if (t.isMemberExpression(left)) {
+          if (left.object.name == 'module' && left.property.name == 'exports') {
+            filename = file.opts.filename;
+          }
           left = left.property;
         }
 
         if (t.isIdentifier(left) && isCreateClass(right)) {
-          addDisplayName(left.name, right);
+          filename = filename || left.name;
+          addDisplayName(filename, right);
         }
       }
     }


### PR DESCRIPTION
We've a very large codebase and are using [parallel-transpile](https://github.com/timecounts/parallel-transpile) to compile code from CJSX down to JS using all available cores before using webpack to stick all the JS together quickly and easily. We want to use this plugin to add the `displayName` to relevant components, but we don't want the default `module.exports = React.createClass` to just be called `exports` - instead we want it named after the file.

This PR does the following things:
- Detects `module.exports` and uses the filename instead of `exports` for the `displayName`
- Trims webpack's mess from the `filename` that is passed in (this is especially useful for hot loading too)
- Automatically ignores file extensions - not just `.js` (e.g. `.jsx`, `.coffee`, `.cjsx`, `.litcoffee`, `.ts`, etc etc)
